### PR TITLE
more idempotence. Adds file hashes to catalog

### DIFF
--- a/internal/catalogserver/api.go
+++ b/internal/catalogserver/api.go
@@ -82,6 +82,7 @@ func convertEntries(entries []medialibrary.MediaEntry) []models.CatalogEntry {
 	for i, entry := range entries {
 		outEntry := models.CatalogEntry{
 			Path:        entry.Path,
+			Hash:        entry.Hash,
 			Description: entry.Description,
 			MimeType:    entry.MimeType,
 			ByteSize:    entry.ByteSize,

--- a/internal/models/natster_api.go
+++ b/internal/models/natster_api.go
@@ -19,6 +19,7 @@ type CatalogEntry struct {
 	Description string `json:"description"`
 	MimeType    string `json:"mime_type"`
 	ByteSize    int64  `json:"byte_size"`
+	Hash        string `json:"hash"`
 }
 
 type ApiResult struct {


### PR DESCRIPTION
To add the file hashes to an existing catalog, just re-run `natster catalog new` with the exact same catalog name and directory as before and it'll just re-generate your catalog's entries list.