### PR TITLE
support querying inbox of unimported shares

### DIFF
--- a/internal/catalogserver/api.go
+++ b/internal/catalogserver/api.go
@@ -37,6 +37,14 @@ func (srv *CatalogServer) startApiSubscriptions() error {
 		return err
 	}
 
+	_, err = srv.nc.QueueSubscribe("natster.local.>", "natsterlocalservices",
+		handleLocalServiceRequest(srv))
+	if err != nil {
+		log.Error(
+			"Failed to subscribe to natster local services subject")
+		return err
+	}
+
 	return nil
 }
 

--- a/internal/catalogserver/client.go
+++ b/internal/catalogserver/client.go
@@ -23,7 +23,7 @@ type Client struct {
 func NewClient(nc *nats.Conn) *Client {
 	return &Client{
 		nc:          nc,
-		dlResponses: make(chan models.TypedApiResult[models.DownloadResponse], 0),
+		dlResponses: make(chan models.TypedApiResult[models.DownloadResponse]),
 	}
 }
 

--- a/internal/catalogserver/local_services.go
+++ b/internal/catalogserver/local_services.go
@@ -1,0 +1,80 @@
+package catalogserver
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/nats-io/nats.go"
+	"github.com/synadia-io/control-plane-sdk-go/syncp"
+	"github.com/synadia-labs/natster/internal/models"
+)
+
+const (
+	synadiaCloudBaseUrl = "https://cloud.synadia.com"
+)
+
+type inboxResponse struct {
+	UnimportedShares []models.CatalogShareSummary `json:"unimported_shares"`
+}
+
+func handleLocalServiceRequest(srv *CatalogServer) func(m *nats.Msg) {
+	return func(m *nats.Msg) {
+		// - natster.local.inbox (req)
+
+		tokens := strings.Split(m.Subject, ".")
+		// shouldn't ever happen, but better safe than sorry
+		if len(tokens) < 3 {
+			_ = m.Respond(models.NewApiResultFail("Bad request", 400))
+			return
+		}
+		scpClient, scpContext := getSynadiaCloudClient(srv.nctx)
+		if tokens[2] == "inbox" {
+			inboxData, err := srv.getInbox(scpClient, scpContext)
+			if err != nil {
+				_ = m.Respond(models.NewApiResultFail(err.Error(), 500))
+			} else {
+				_ = m.Respond(models.NewApiResultPass(inboxData))
+			}
+		}
+	}
+}
+
+func (srv *CatalogServer) getInbox(scpClient *syncp.APIClient, scpContext context.Context) (*inboxResponse, error) {
+	cats, err := srv.globalServiceClient.GetMyCatalogs()
+	if err != nil {
+		return nil, err
+	}
+
+	resp, _, err := scpClient.AccountAPI.ListSubjectImports(scpContext, srv.nctx.AccountID).Execute()
+	if err != nil {
+		return nil, err
+	}
+	importedSubjects := make([]string, len(resp.Items))
+	for i, subject := range resp.Items {
+		importedSubjects[i] = subject.Name
+	}
+
+	inboxCatalogs := make([]models.CatalogShareSummary, 0)
+	for _, catalog := range cats {
+		target := fmt.Sprintf("natster_%s", strings.ToLower(catalog.Catalog))
+		if !slices.Contains(importedSubjects, target) &&
+			catalog.FromAccount != srv.nctx.AccountPublicKey {
+			inboxCatalogs = append(inboxCatalogs, catalog)
+		}
+	}
+	return &inboxResponse{
+		UnimportedShares: inboxCatalogs,
+	}, nil
+}
+
+func getSynadiaCloudClient(nctx *models.NatsterContext) (*syncp.APIClient, context.Context) {
+	client := syncp.NewAPIClient(syncp.NewConfiguration())
+	ctxx := context.WithValue(context.Background(), syncp.ContextServerVariables, map[string]string{
+		"baseUrl": synadiaCloudBaseUrl,
+	})
+	ctxx = context.WithValue(ctxx, syncp.ContextAccessToken, nctx.Token)
+
+	return client, ctxx
+}

--- a/internal/catalogserver/server.go
+++ b/internal/catalogserver/server.go
@@ -38,6 +38,7 @@ func (srv *CatalogServer) Start(uiPort int) error {
 		return err
 	}
 	log.Info("Natster Media Catalog Server Started")
+	log.Info("Local (private) services are available on 'natster.local.>'")
 
 	srv.startHeartbeatEmitter()
 	srv.startWebServer(uiPort)

--- a/natster/natster.go
+++ b/natster/natster.go
@@ -46,6 +46,10 @@ func main() {
 	newcat.Arg("path", "Path to the root directory containing the catalog's media").Required().ExistingDirVar(&HubOpts.RootPath)
 	newcat.Action(NewCatalog)
 
+	inbox := catalog.Command("inbox", "Lists the catalogs that have been shared with you that have not yet been imported").
+		HelpLong("This requires at least one catalog server running within the selected context. Will prompt the user to choose a catalog to import.")
+	inbox.Action(RenderInbox)
+
 	sharecat := catalog.Command("share", "Shares a catalog with a target account")
 	sharecat.Arg("name", "The name of the catalog to share").Required().StringVar(&ShareOpts.Name)
 	sharecat.Arg("account", "Public key of the target account").Required().StringVar(&ShareOpts.AccountKey)


### PR DESCRIPTION
This adds support for querying an inbox of unimported shares. It does so by making a request available on `natster.local.inbox`, which is not a subject that matches any Natster exports, and so will only be available from within that account context.

*Note* - the UI should provide some kind of affordance so that we can tell the difference between a truly empty inbox versus not being able to query an inbox because we have no running catalogs. We can detect that we have no running catalogs but we can also have the UI watch for the `no responders` reply to the inbox query. If we get that, we can say that there are no catalog servers running, therefore inbox is unavailable at the moment.

The reason `natster catalog inbox` is a different function than `catalog import` is because we don't need a running catalog server to do an import, but we do need one to obtain an inbox, so I separated the functions to keep from giving people weird or unexpected errors.