### PR TITLE
adds naive directory monitoring for catalog

### DIFF
--- a/internal/catalogserver/init.go
+++ b/internal/catalogserver/init.go
@@ -35,6 +35,7 @@ func CliStart(ctx *models.NatsterContext, opts *models.Options, hubopts *models.
 	log.Info(
 		"Opened Media Catalog",
 		log.String("name", hubopts.Name),
+		log.String("rootpath", library.RootDir),
 	)
 
 	server := New(ctx, nc, library, hubopts.AllowAll)


### PR DESCRIPTION
The reason this is "naive" is because we can't tell when a file is done being written to the directory live. So, we wait 1 second and then grab the hash from there. If it takes longer than 1 second for the file to be written, then the hash and size will be incorrect in the catalog. It'll still go to the right file, but the metadata will be "off".

If you're copying around 10GB files, it's probably best to do so with the catalog server off and then do an import.