### PR TITLE
rejects shares to bogus account keys

### DIFF
--- a/internal/globalservice/event_api.go
+++ b/internal/globalservice/event_api.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
+	"github.com/nats-io/nkeys"
 	"github.com/synadia-labs/natster/internal/models"
 )
 
@@ -329,6 +330,10 @@ func (srv *GlobalService) validateCatalogSharedEvent(accountKey string, evt mode
 	}
 	if acct == nil {
 		return errors.New("rejecting catalog_shared event, can't share from a nonexistent account")
+	}
+	if !nkeys.IsValidPublicAccountKey(evt.Target) {
+		// sadly this will prevent us from sharing to ABOB or AALICE
+		return errors.New("target account is not a valid public key")
 	}
 	if slices.ContainsFunc(acct.OutShares, func(cat shareEntry) bool {
 		return cat.Account == accountKey && cat.Catalog == evt.Catalog

--- a/natster/catalog.go
+++ b/natster/catalog.go
@@ -344,7 +344,7 @@ func ShareCatalog(ctx *fisk.ParseContext) error {
 		return err
 	}
 
-	fmt.Printf("Shared catalog '%s' with target '%s'. Note: Natster makes no guarantees that the target account exists.\n",
+	fmt.Printf("Shared catalog '%s' with target '%s'.\nNote: Natster's backend makes no guarantees that the target account exists.\n",
 		ShareOpts.Name,
 		ShareOpts.AccountKey,
 	)


### PR DESCRIPTION
this way people can't spam the event log with meaningless shares